### PR TITLE
Add DateTime utility functions in Util component

### DIFF
--- a/components/Util.php
+++ b/components/Util.php
@@ -4,7 +4,47 @@
 namespace app\components;
 
 
+use app\models\exceptions\StaticClassNotInstantiableException;
+
 class Util
 {
-    
+    public function __construct()
+    {
+        throw new StaticClassNotInstantiableException();
+    }
+
+    /**
+     * Converts a DateTimeInterface into a string to save it in database
+     *
+     * @param \DateTimeInterface $dateTime the datetime to convert
+     * @return string the converted datetime
+     */
+    public static function getDateTimeFormattedForDatabase(\DateTimeInterface $dateTime): string
+    {
+        return $dateTime->format('Y-m-d H:i:s');
+    }
+
+    /**
+     * Converts a string dateTime to a DateTimeObject
+     *
+     * @param string $stringDateTime the string dateTime to get as DateTime object
+     * @param bool $getAsImmutable if true, a {@see \DateTimeImmutable} will be returned. Otherwise, it will be a {@see \DateTime}
+     * @return \DateTimeInterface
+     */
+    public static function getDateTimeFromDatabaseString(string $stringDateTime, bool $getAsImmutable = false): \DateTimeInterface
+    {
+        if($getAsImmutable) {
+            $class = \DateTimeImmutable::class;
+        } else {
+            $class = \DateTime::class;
+        }
+        /** @var \DateTime|\DateTimeImmutable $class */
+
+        $object = $class::createFromFormat('Y-m-d H:i:s', $stringDateTime);
+        if($object === false) {
+            throw new \InvalidArgumentException('String ' . $stringDateTime . ' is not valid');
+        }
+
+        return $object;
+    }
 }

--- a/models/exceptions/StaticClassNotInstantiableException.php
+++ b/models/exceptions/StaticClassNotInstantiableException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace app\models\exceptions;
+
+
+class StaticClassNotInstantiableException extends \Exception
+{
+
+}


### PR DESCRIPTION
Added two functions in Util component:
- getDateTimeFormattedForDatabase to convert a datetime to string, in
order to save it in database
- getDateTimeFromDatabaseString to convert a database string date to a
DateTime (or DateTimeImmutable) object