### PR TITLE
Fix #80

### DIFF
--- a/controllers/ProposalController.php
+++ b/controllers/ProposalController.php
@@ -83,9 +83,12 @@ class ProposalController extends MainController
             $selectedProposal->proposalFileHistories,
 
         );
-        $lastProposalContent = $selectedProposal->proposalContentHistories[
-            count($selectedProposal->proposalContentHistories)-1
-        ];
+        $lastProposalContent = ProposalContentHistory::find()
+            ->where(['proposal_id' => $selectedProposal->id])
+            ->orderBy('date DESC')
+            ->limit(1)
+            ->one();
+
         $approvalsCount = Review::find()->where(['proposal_id' => $selectedProposal->id])
             ->andWhere(['status' => \app\models\Review::REVIEW_STATUS_APPROVED])
             ->count();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | Yes
| New feature?  | No
| Fixed issues  | Fixes #80

`$lastProposalContent` was not retrieved correctly